### PR TITLE
Bool serializer fix

### DIFF
--- a/PListSerializer.cpp
+++ b/PListSerializer.cpp
@@ -11,12 +11,7 @@ static QDomElement textElement(QDomDocument& doc, const char *tagName, QString c
 static QDomElement serializePrimitive(QDomDocument &doc, const QVariant &variant) {
 	QDomElement result;
 	if (variant.type() == QVariant::Bool) {
-		if (variant.toBool()) {
-			result.setTagName(QStringLiteral("true"));
-		}
-		else {
-			result.setTagName(QStringLiteral("false"));
-		}
+        result = textElement(doc, variant.toBool() ? "true" : "false", "" );
 	}
 	else if (variant.type() == QVariant::Date) {
 		result = textElement(doc, "date", variant.toDate().toString(Qt::ISODate));


### PR DESCRIPTION
 There was a bug, that a boolean with False value wasn't serialized to PLIST. Create a new textElement instead of setTagName fixed the problem. The problem was on Qt version 5.0 and above.
